### PR TITLE
Don't get __metamodule_init__ on the instance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Editor temporary
+.*.swp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/metamodule.py
+++ b/metamodule.py
@@ -98,8 +98,8 @@ def install(name, class_=FancyModule):
         new_module = orig_module
     except TypeError:
         new_module = _hacky_make_metamodule(orig_module, class_)
-    if hasattr(new_module, "__metamodule_init__"):
-        new_module.__metamodule_init__()
+    getattr(type(new_module), "__metamodule_init__", lambda self: None)(
+        new_module)
     sys.modules[name] = new_module
 
 def _hacky_make_metamodule(orig_module, class_):

--- a/tests/module_custom2.py
+++ b/tests/module_custom2.py
@@ -1,9 +1,13 @@
 from types import ModuleType
 
 class MyModule(ModuleType):
-    # No __metamodule_init__, to make sure that that's legal
+    # Make sure that having no __metamodule_init__ is legal, and does not get
+    # routed through __getattr__.
 
-    class_attr = "foo"
+    def __getattr__(self, attr):
+        if attr == "class_attr":
+            return "foo"
+        raise AttributeError
 
 import metamodule
 metamodule.install(__name__, MyModule)


### PR DESCRIPTION
Get it on the class, like a proper `__dunder__`.  Also avoids triggering
`__getattr__` if the latter is defined but not the former.

See #2.
